### PR TITLE
arm64: dts: amlogic: s922x-oes-plus-00050000: fix Ethernet RGMII delay configuration

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b-s922x-oes-plus-00050000.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-s922x-oes-plus-00050000.dts
@@ -12,6 +12,7 @@
 
 &ethmac {
 	phy-mode = "rgmii-rxid";
-	amlogic,prg-eth-reg0 = <0xffffffff 0x00001629>;
-	amlogic,prg-eth-reg1 = <0xffffffff 0x00050000>;
+	amlogic,invert-rxclk;
+	amlogic,keep-rx-internal-delay;
+	rx-internal-delay-ps = <1000>;
 };


### PR DESCRIPTION
6.18.y 驱动删除了 meson8b_prg_eth_override() 函数，即 amlogic,prg-eth-reg0 和 amlogic,prg-eth-reg1 这两个 DTS 属性在新内核中完全被忽略了。

将 DTS 中废弃的寄存器覆写替换为 6.18.y 驱动支持的新属性：

```
- amlogic,invert-rxclk — 等效于原 PRG_ETH0 Bit 3
- amlogic,keep-rx-internal-delay — 阻止驱动在 rgmii-rxid 模式下清零 MAC 端 RX 延迟
- rx-internal-delay-ps = <1000> — 等效于原 PRG_ETH1 的 CFG_RXCLK_DLY=5（5 × 200ps）
```