### PR TITLE
watchdog: sunxi: raise restart priority above PSCI to fix reboot on H6 + Crust

### DIFF
--- a/drivers/watchdog/sunxi_wdt.c
+++ b/drivers/watchdog/sunxi_wdt.c
@@ -282,7 +282,15 @@ static int sunxi_wdt_probe(struct platform_device *pdev)
 
 	watchdog_init_timeout(&sunxi_wdt->wdt_dev, timeout, dev);
 	watchdog_set_nowayout(&sunxi_wdt->wdt_dev, nowayout);
-	watchdog_set_restart_priority(&sunxi_wdt->wdt_dev, 128);
+	/*
+	 * Use a restart priority higher than PSCI (129) so that the watchdog
+	 * hardware reset fires before PSCI SYSTEM_RESET is attempted.
+	 * On Allwinner H6 + Crust SCP, PSCI SYSTEM_RESET is forwarded via
+	 * SCPI to the PMIC as a power-cycle, which results in power-off
+	 * rather than a reboot.  The sunxi watchdog performs a true SoC
+	 * hardware reset and must therefore run first.
+	 */
+	watchdog_set_restart_priority(&sunxi_wdt->wdt_dev, 192);
 
 	watchdog_set_drvdata(&sunxi_wdt->wdt_dev, sunxi_wdt);
 


### PR DESCRIPTION
Use a restart priority higher than PSCI (129) so that the watchdog
hardware reset fires before PSCI SYSTEM_RESET is attempted.
On Allwinner H6 + Crust SCP, PSCI SYSTEM_RESET is forwarded via
SCPI to the PMIC as a power-cycle, which results in power-off
rather than a reboot.  The sunxi watchdog performs a true SoC
hardware reset and must therefore run first.

According to user testing, this fixes the issue where the reboot command would cause Allwinner H6 series devices to power off instead of rebooting.

https://github.com/ophub/amlogic-s9xxx-armbian/issues/3534#issuecomment-4628937026