### PR TITLE
arm64: dts: rockchip: fix MD1000 USB ports

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-md1000.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-md1000.dts
@@ -261,6 +261,7 @@
 };
 
 &combphy1 {
+	phy-supply = <&vcc5v0_host>;
 	status = "okay";
 };
 
@@ -549,6 +550,10 @@
 	status = "okay";
 };
 
+&usb2phy0 {
+	status = "okay";
+};
+
 &usb2phy0_host {
 	phy-supply = <&vcc5v0_host>;
 	status = "okay";
@@ -578,6 +583,12 @@
 };
 
 &usb_host0_ohci {
+	status = "okay";
+};
+
+&usb_host0_xhci {
+	/delete-property/ extcon;
+	dr_mode = "host";
 	status = "okay";
 };
 


### PR DESCRIPTION
Fix USB3 not working on MD1000 RK3566 board.

Three items were missing from the previous PR https://github.com/ophub/linux-6.18.y/pull/2:

Enable usb2phy0 parent node - without this, the USB2 PHY backing
the USB3 controller (usb_host1_xhci) never initializes, so USB3
does not work even though the child ports and xHCI controller are
enabled.

Add phy-supply to combphy1 - provide vcc5v0_host power supply to
the combo PHY used for USB3.

Enable usb_host0_xhci in host mode - enable the OTG port USB3
xHCI controller with dr_mode = "host".

Tested on MD1000 RK3566: USB3 5Gbps works after these changes.