### PR TITLE
arm64: dts: amlogic: meson-sm1-hk1box-vontar-x3: disable unused PWM_AO_A to fix sys_led GPIO conflict

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
@@ -260,3 +260,7 @@
 		reg = <0x12 0x10>;
 	};
 };
+
+&pwm_AO_ab {
+	status = "disabled";
+};


### PR DESCRIPTION
sys_led (GPIOAO_11) conflicts with PWM_AO_A pinmux function enabled by
the shared meson-sm1-ac2xx.dtsi, causing the LED to lose GPIO control
under 6.12.y+. Disable PWM_AO_A for this board since it's unused.

Tested on real hardware.
$ uname -a
Linux armbian 6.18.37-yourname #1 SMP PREEMPT_DYNAMIC Sat Jul  4 10:49:12 UTC 2026 aarch64 GNU/Linux