### PR TITLE
arm64: dts: rockchip: update easepi-a2 and easepi-r2 dtbs

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-easepi-a2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-easepi-a2.dts
@@ -1,159 +1,38 @@
-// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
-/*
- * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
- * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
- * Copyright (c) 2025 jjm2473 <jjm2473@gmail.com>
- */
-
 /dts-v1/;
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/pinctrl/rockchip.h>
-#include <dt-bindings/soc/rockchip,vop2.h>
-#include "rk3568.dtsi"
+
+#include "rk3568-roc-k40pro.dtsi"
+#include "rk3568-ip.dtsi"
+#include "rk3568-ip-rk809.dtsi"
 
 / {
 	compatible = "linkease,easepi-a2", "easepi,a2", "rockchip,rk3568";
 	model = "EasePi A2";
-
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		ramoops: ramoops@110000 {
-			compatible = "ramoops";
-			reg = <0 0x110000 0 0xf0000>;
-			console-size = <0x80000>;
-			ftrace-size = <0x00000>;
-			pmsg-size = <0x50000>;
-			record-size = <0x20000>;
-		};
-	};
+	eth_order = "0000:01:00.0";
+	kdebug = "0";
+	hwmodel_id = "A2";
+	hw_support = "hdmi";
 
 	aliases {
-		mmc0 = &sdmmc0;
-		mmc1 = &sdhci;
-		mmc2 = &sdmmc2;
-
 		ethernet0 = &pcie_eth0;
-
-		serial0 = &uart8;
-
-		led-boot = &led_green;
-		led-failsafe = &led_green;
-		led-running = &led_green;
-		led-upgrade = &led_green;
+		/delete-property/ ethernet1;
+		mmc2 = &sdmmc2;
 	};
 
 	chosen {
-		stdout-path = "serial2:1500000n8";
+		power-key-factory-reset;
+		power-key-dbclick;
 	};
 
-	adc_keys: adc-keys {
-		compatible = "adc-keys";
-		io-channels = <&saradc 0>;
-		io-channel-names = "buttons";
-		keyup-threshold-microvolt = <1750000>;
-		poll-interval = <100>;
-
-		vol-up-key {
-			label = "volume up";
-			linux,code = <KEY_VOLUMEUP>;
-			press-threshold-microvolt = <1750>;
-		};
-
-		vol-down-key {
-			label = "volume down";
-			linux,code = <KEY_VOLUMEDOWN>;
-			press-threshold-microvolt = <297500>;
-		};
-
-		menu-key {
-			label = "menu";
-			linux,code = <KEY_MENU>;
-			press-threshold-microvolt = <980000>;
-		};
-
-		back-key {
-			label = "back";
-			linux,code = <KEY_BACK>;
-			press-threshold-microvolt = <1305500>;
-		};
-	};
-
-	dc_12v: dc-12v {
-		compatible = "regulator-fixed";
-		regulator-name = "dc_12v";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <12000000>;
-		regulator-max-microvolt = <12000000>;
-	};
-	vcc5v0_sys: vcc5v0-sys {
-		compatible = "regulator-fixed";
-		regulator-name = "vcc5v0_sys";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		vin-supply = <&dc_12v>;
-	};
-	vcc3v3_sys: vcc3v3-sys {
-		compatible = "regulator-fixed";
-		regulator-name = "vcc3v3_sys";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		vin-supply = <&dc_12v>;
-	};
-	vcc5v0_otg: vcc5v0-otg-regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "vcc5v0_otg";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		vin-supply = <&vcc5v0_sys>;
-	};
-	pcie30_avdd0v9: pcie30-avdd0v9 {
-		compatible = "regulator-fixed";
-		regulator-name = "pcie30_avdd0v9";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <900000>;
-		regulator-max-microvolt = <900000>;
-		vin-supply = <&vcc3v3_sys>;
-	};
-	pcie30_avdd1v8: pcie30-avdd1v8 {
-		compatible = "regulator-fixed";
-		regulator-name = "pcie30_avdd1v8";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		vin-supply = <&vcc3v3_sys>;
-	};
 	vcc3v3_nvme: vcc3v3-nvme-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc3v3_nvme";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		enable-active-high;
-		gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
 		vin-supply = <&dc_12v>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&vcc3v3_nvme_en>;
-	};
-
-	sdio_pwrseq: sdio-pwrseq {
-		compatible = "mmc-pwrseq-simple";
-		clocks = <&rk809 1>;
-		clock-names = "ext_clock";
-		pinctrl-names = "default";
-		pinctrl-0 = <&wifi_enable_h>;
 	};
 
 	ir-receiver {
@@ -163,613 +42,31 @@
 		pinctrl-0 = <&ir_receiver_pin>;
 	};
 
-	hdmi-con {
-		compatible = "hdmi-connector";
-		type = "a";
-
-		port {
-			hdmi_con_in: endpoint {
-				remote-endpoint = <&hdmi_out_con>;
-			};
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
+	fan0: gpio_fan0 {
+		compatible = "gpio-fan";
+		fan-supply = <&dc_12v>;
+		gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map =
+				<   0 0>,
+				<2500 1>;
 		pinctrl-names = "default";
-		pinctrl-0 = <&led_green_en>;
-
-		led_green: green {
-			gpios = <&gpio2 RK_PD7 GPIO_ACTIVE_HIGH>;
-			label = "green:sys";
-			linux,default-trigger = "timer";
-		};
+		pinctrl-0 = <&fan0_en_h>;
+		#cooling-cells = <2>;
 	};
 
-};
-
-/* ===== Carrier board (roc-k40pro) overrides ===== */
-
-&gmac0 {
-	phy-mode = "rgmii";
-	clock_in_out = "input";
-
-	snps,reset-gpio = <&gpio2 RK_PD3 GPIO_ACTIVE_LOW>;
-	snps,reset-active-low;
-	/* Reset time is 15ms, 50ms for rtl8211f */
-	snps,reset-delays-us = <0 15000 50000>;
-
-	assigned-clocks = <&cru SCLK_GMAC0_RX_TX>, <&cru SCLK_GMAC0>;
-	assigned-clock-parents = <&cru SCLK_GMAC0_RGMII_SPEED>;
-	assigned-clock-rates = <0>, <125000000>;
-	phy-handle = <&rgmii_phy0>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&gmac0_miim
-		     &gmac0_tx_bus2
-		     &gmac0_rx_bus2
-		     &gmac0_rgmii_clk
-		     &gmac0_rgmii_bus>;
-
-	tx_delay = <0x3c>;
-	rx_delay = <0x2f>;
-
-	status = "okay";
-};
-
-&gmac1 {
-	phy-mode = "rgmii";
-	clock_in_out = "input";
-
-	snps,reset-gpio = <&gpio2 RK_PD1 GPIO_ACTIVE_LOW>;
-	snps,reset-active-low;
-	/* Reset time is 15ms, 50ms for rtl8211f */
-	snps,reset-delays-us = <0 15000 50000>;
-
-	assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
-	assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>;
-	assigned-clock-rates = <0>, <125000000>;
-	phy-handle = <&rgmii_phy1>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&gmac1m1_miim
-		     &gmac1m1_tx_bus2
-		     &gmac1m1_rx_bus2
-		     &gmac1m1_rgmii_clk
-		     &gmac1m1_rgmii_bus>;
-
-	tx_delay = <0x4f>;
-	rx_delay = <0x26>;
-
-	status = "okay";
-};
-
-&mdio0 {
-	rgmii_phy0: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <0x1>;
-		pinctrl-0 = <&eth_phy0_reset_pin>;
+	fan1: gpio_fan1 {
+		compatible = "gpio-fan";
+		fan-supply = <&vcc5v0_sys>;
+		gpios = <&gpio3 RK_PA5 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map =
+				<   0 0>,
+				<2500 1>;
 		pinctrl-names = "default";
-		realtek,led-data = <0xAC10>;
-	};
-};
-
-&mdio1 {
-	rgmii_phy1: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reg = <0x1>;
-		pinctrl-0 = <&eth_phy1_reset_pin>;
-		pinctrl-names = "default";
-		realtek,led-data = <0xAC10>;
-	};
-};
-
-&combphy0 {
-	rockchip,dis-u3otg0-port; /* disable USB3.0 */
-	status = "okay";
-};
-
-&combphy1 {
-	status = "okay";
-};
-
-&combphy2 {
-	status = "okay";
-};
-
-&cpu0 {
-	cpu-supply = <&vdd_cpu>;
-};
-
-&cpu1 {
-	cpu-supply = <&vdd_cpu>;
-};
-
-&cpu2 {
-	cpu-supply = <&vdd_cpu>;
-};
-
-&cpu3 {
-	cpu-supply = <&vdd_cpu>;
-};
-
-&gpu {
-	mali-supply = <&vdd_gpu>;
-	status = "okay";
-};
-
-&hdmi {
-	avdd-0v9-supply = <&vdda0v9_image>;
-	avdd-1v8-supply = <&vcca1v8_image>;
-	status = "okay";
-};
-
-&hdmi_in {
-	hdmi_in_vp0: endpoint {
-		remote-endpoint = <&vp0_out_hdmi>;
-	};
-};
-
-&hdmi_out {
-	hdmi_out_con: endpoint {
-		remote-endpoint = <&hdmi_con_in>;
-	};
-};
-
-&hdmi_sound {
-	status = "okay";
-};
-
-&i2c0 {
-	status = "okay";
-
-	vdd_cpu: regulator@1c {
-		compatible = "tcs,tcs4525";
-		reg = <0x1c>;
-		fcs,suspend-voltage-selector = <1>;
-		regulator-name = "vdd_cpu";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <800000>;
-		regulator-max-microvolt = <1150000>;
-		regulator-ramp-delay = <2300>;
-		vin-supply = <&vcc5v0_sys>;
-
-		regulator-state-mem {
-			regulator-off-in-suspend;
-		};
-	};
-
-	rk809: pmic@20 {
-		compatible = "rockchip,rk809";
-		reg = <0x20>;
-		interrupt-parent = <&gpio0>;
-		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
-		#clock-cells = <1>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&pmic_int>;
-		rockchip,system-power-controller;
-		vcc1-supply = <&vcc3v3_sys>;
-		vcc2-supply = <&vcc3v3_sys>;
-		vcc3-supply = <&vcc3v3_sys>;
-		vcc4-supply = <&vcc3v3_sys>;
-		vcc5-supply = <&vcc3v3_sys>;
-		vcc6-supply = <&vcc3v3_sys>;
-		vcc7-supply = <&vcc3v3_sys>;
-		vcc8-supply = <&vcc3v3_sys>;
-		vcc9-supply = <&vcc3v3_sys>;
-		wakeup-source;
-		long-press-off-time-sec = <10>;
-
-		regulators {
-			vdd_logic: DCDC_REG1 {
-				regulator-name = "vdd_logic";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-initial-mode = <0x2>;
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <1350000>;
-				regulator-ramp-delay = <6001>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_gpu: DCDC_REG2 {
-				regulator-name = "vdd_gpu";
-				regulator-always-on;
-				regulator-initial-mode = <0x2>;
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <1350000>;
-				regulator-ramp-delay = <6001>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc_ddr: DCDC_REG3 {
-				regulator-name = "vcc_ddr";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-initial-mode = <0x2>;
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-				};
-			};
-
-			vdd_npu: DCDC_REG4 {
-				regulator-name = "vdd_npu";
-				regulator-initial-mode = <0x2>;
-				regulator-min-microvolt = <500000>;
-				regulator-max-microvolt = <1350000>;
-				regulator-ramp-delay = <6001>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc_1v8: DCDC_REG5 {
-				regulator-name = "vcc_1v8";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdda0v9_image: LDO_REG1 {
-				regulator-name = "vdda0v9_image";
-				regulator-min-microvolt = <950000>;
-				regulator-max-microvolt = <950000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdda_0v9: LDO_REG2 {
-				regulator-name = "vdda_0v9";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <900000>;
-				regulator-max-microvolt = <900000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdda0v9_pmu: LDO_REG3 {
-				regulator-name = "vdda0v9_pmu";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <900000>;
-				regulator-max-microvolt = <900000>;
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <900000>;
-				};
-			};
-
-			vccio_acodec: LDO_REG4 {
-				regulator-name = "vccio_acodec";
-				regulator-min-microvolt = <3300000>;
-				regulator-max-microvolt = <3300000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vccio_sd: LDO_REG5 {
-				regulator-name = "vccio_sd";
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <3300000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc3v3_pmu: LDO_REG6 {
-				regulator-name = "vcc3v3_pmu";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <3300000>;
-				regulator-max-microvolt = <3300000>;
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <3300000>;
-				};
-			};
-
-			vcca_1v8: LDO_REG7 {
-				regulator-name = "vcca_1v8";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcca1v8_pmu: LDO_REG8 {
-				regulator-name = "vcca1v8_pmu";
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <1800000>;
-				};
-			};
-
-			vcca1v8_image: LDO_REG9 {
-				regulator-name = "vcca1v8_image";
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc_3v3: SWITCH_REG1 {
-				regulator-name = "vcc_3v3";
-				regulator-always-on;
-				regulator-boot-on;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc3v3_sd: SWITCH_REG2 {
-				regulator-name = "vcc3v3_sd";
-				regulator-always-on;
-				regulator-boot-on;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-		};
-
-	};
-};
-
-&i2s0_8ch {
-	status = "okay";
-};
-
-&pcie30phy {
-	data-lanes = <1 2>;
-	status = "okay";
-};
-
-&pcie3x1 {
-	num-lanes = <1>;
-	status = "okay";
-};
-
-&pcie3x2 {
-	num-lanes = <1>;
-	status = "okay";
-};
-
-&pinctrl {
-	gmac0 {
-		eth_phy0_reset_pin: eth-phy0-reset-pin {
-			rockchip,pins = <2 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-
-	gmac1 {
-		eth_phy1_reset_pin: eth-phy1-reset-pin {
-			rockchip,pins = <2 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-
-	leds {
-		led_green_en: led-green-en {
-			rockchip,pins =
-				<2 RK_PD7 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-	pmic {
-		pmic_int: pmic-int {
-			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-
-	wireless-wlan {
-		wifi_host_wake_irq: wifi-host-wake-irq {
-			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
-		};
-	};
-
-	sdio-pwrseq {
-		wifi_enable_h: wifi-enable-h {
-			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	ir-receiver {
-		ir_receiver_pin: ir-receiver-pin {
-			rockchip,pins = <0 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	wireless-bluetooth {
-		uart8_gpios: uart8-gpios {
-			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	nvme {
-		vcc3v3_nvme_en: vcc3v3-nvme-en {
-			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	oled {
-		oled_en: oled-en {
-			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_output_high>;
-		};
-	};
-
-	bluetooth {
-		bt_shutdown_gpio: bt-shutdown-gpio {
-			rockchip,pins = <4 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-		bt_host_wake_gpio: bt-host-wake-gpio {
-			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
-		};
-		bt_device_wake_gpio: bt-device-wake-gpio {
-			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
+		pinctrl-0 = <&fan1_en_h>;
+		#cooling-cells = <2>;
 	};
 
 };
-
-&pmu_io_domains {
-	pmuio1-supply = <&vcc3v3_pmu>;
-	pmuio2-supply = <&vcc3v3_pmu>;
-	vccio1-supply = <&vccio_acodec>;
-	vccio3-supply = <&vccio_sd>;
-	vccio4-supply = <&vcc_1v8>;
-	vccio5-supply = <&vcc_3v3>;
-	vccio6-supply = <&vcc_1v8>;
-	vccio7-supply = <&vcc_3v3>;
-	status = "okay";
-};
-
-&saradc {
-	vref-supply = <&vcca_1v8>;
-	status = "okay";
-};
-
-&sdhci {
-	bus-width = <8>;
-	max-frequency = <200000000>;
-	non-removable;
-	pinctrl-names = "default";
-	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd>;
-	status = "okay";
-};
-
-&sdmmc0 {
-	max-frequency = <150000000>;
-	no-sdio;
-	no-mmc;
-	bus-width = <4>;
-	cap-mmc-highspeed;
-	cap-sd-highspeed;
-	disable-wp;
-	vmmc-supply = <&vcc3v3_sd>;
-	vqmmc-supply = <&vccio_sd>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
-	status = "okay";
-};
-
-&tsadc {
-	rockchip,hw-tshut-mode = <1>;
-	rockchip,hw-tshut-polarity = <0>;
-	status = "okay";
-};
-
-&uart2 {
-	status = "okay";
-};
-
-&usb_host0_ehci {
-	status = "okay";
-};
-
-&usb_host0_ohci {
-	status = "okay";
-};
-
-/* OTG Only USB2.0, Only device mode */
-&usb_host0_xhci {
-	phys = <&usb2phy0_otg>;
-	phy-names = "usb2-phy";
-	extcon = <&usb2phy0>;
-	maximum-speed = "high-speed";
-	dr_mode = "peripheral";
-	status = "okay";
-};
-
-&usb_host1_ehci {
-	status = "okay";
-};
-
-&usb_host1_ohci {
-	status = "okay";
-};
-
-&usb_host1_xhci {
-	status = "okay";
-};
-
-&usb2phy0 {
-	status = "okay";
-};
-
-&usb2phy0_host {
-	phy-supply = <&vcc5v0_otg>;
-	status = "okay";
-};
-
-&usb2phy0_otg {
-	vbus-supply = <&vcc5v0_otg>;
-	status = "okay";
-};
-
-&usb2phy1 {
-	status = "okay";
-};
-
-&usb2phy1_host {
-	phy-supply = <&vcc5v0_otg>;
-	status = "okay";
-};
-
-&usb2phy1_otg {
-	phy-supply = <&vcc5v0_otg>;
-	status = "okay";
-};
-
-&vop {
-	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
-	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
-	status = "okay";
-};
-
-&vop_mmu {
-	status = "okay";
-};
-
-&vp0 {
-	vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
-		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
-		remote-endpoint = <&hdmi_in_vp0>;
-	};
-};
-
-/* ===== EasePi A2 board-specific overrides ===== */
 
 &gmac0 {
 	status = "disabled";
@@ -779,33 +76,35 @@
 	status = "disabled";
 };
 
-// Configure WL_REG_ON pin
+//配置WL_REG_ON引脚
 &sdio_pwrseq {
 	status = "okay";
 	reset-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
 	post-power-on-delay-ms = <200>;
 };
 
-// bluetooth - mainline kernel serdev on uart8 (GPIO2 pins = hardware connection)
-&uart8 {
-	status = "okay";
+// 配置WL_HOST_WAKE引脚，OOB模式时，该引脚必须配置
+&wireless_wlan {
 	pinctrl-names = "default";
-	pinctrl-0 = <&uart8m0_xfer &uart8m0_ctsn &uart8m0_rtsn>;
-	uart-has-rtscts;
+	pinctrl-0 = <&wifi_host_wake_irq>;
+	WIFI,host_wake_irq = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
+	wifi_chip_type = "ap6255";
+	status = "okay";
+};
 
-	bluetooth {
-		compatible = "brcm,bcm4345c5";
-		clocks = <&rk809 1>;
-		clock-names = "ext_clock";
-		host-wakeup-gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
-		device-wakeup-gpios = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
-		shutdown-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
-		max-speed = <1500000>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&bt_host_wake_gpio &bt_device_wake_gpio &bt_shutdown_gpio>;
-		vbat-supply = <&vcc_3v3>;
-		vddio-supply = <&vcc_1v8>;
-	};
+&wireless_bluetooth {
+	compatible = "bluetooth-platdata";
+	clocks = <&rk809 1>;
+	clock-names = "ext_clock";
+	//wifi-bt-power-toggle;
+	uart_rts_gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default", "rts_gpio";
+	pinctrl-0 = <&uart8m0_rtsn>;
+	pinctrl-1 = <&uart8_gpios>;
+	BT,reset_gpio	= <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+	BT,wake_gpio	 = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
+	BT,wake_host_irq = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+	status = "disabled";
 };
 
 // wifi
@@ -826,6 +125,11 @@
 };
 
 &pcie2x1 {
+	clocks = <&cru ACLK_PCIE20_MST>, <&cru ACLK_PCIE20_SLV>,
+		 <&cru ACLK_PCIE20_DBI>, <&cru PCLK_PCIE20>,
+		 <&cru CLK_PCIE20_AUX_NDFT>;
+	clock-names = "aclk_mst", "aclk_slv",
+		      "aclk_dbi", "pclk", "aux";
 	reset-gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
 
@@ -834,7 +138,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		pcie_eth0: pcie-eth@0,0 {
+		pcie_eth0: pcie@00,0 {
 			compatible = "pci10ec,8125";
 			reg = <0x000000 0 0 0 0>;
 
@@ -845,19 +149,66 @@
 };
 
 &pcie3x1 {
+	clocks = <&cru ACLK_PCIE30X1_MST>, <&cru ACLK_PCIE30X1_SLV>,
+		 <&cru ACLK_PCIE30X1_DBI>, <&cru PCLK_PCIE30X1>,
+		 <&cru CLK_PCIE30X1_AUX_NDFT>;
+	clock-names = "aclk_mst", "aclk_slv",
+		      "aclk_dbi", "pclk", "aux";
 	reset-gpios = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
 	vpcie3v3-supply = <&vcc3v3_nvme>;
 	status = "okay";
 };
 
 &pcie3x2 {
+	clocks = <&cru ACLK_PCIE30X2_MST>, <&cru ACLK_PCIE30X2_SLV>,
+		 <&cru ACLK_PCIE30X2_DBI>, <&cru PCLK_PCIE30X2>,
+		 <&cru CLK_PCIE30X2_AUX_NDFT>;
+	clock-names = "aclk_mst", "aclk_slv",
+		      "aclk_dbi", "pclk", "aux";
 	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
 	vpcie3v3-supply = <&vcc3v3_nvme>;
 	status = "okay";
 };
 
 &usb_host0_xhci {
-	status = "okay";
+	status = "disabled";
+};
+
+&pinctrl {
+	bluetooth {
+		bt_shutdown_gpio: bt-shutdown-gpio {
+			rockchip,pins = <4 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		bt_host_wake_gpio: bt-host-wake-gpio {
+			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+		bt_device_wake_gpio: bt-device-wake-gpio {
+			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+	ir-receiver {
+		ir_receiver_pin: ir-receiver-pin {
+			rockchip,pins = <0 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+	nvme {
+		vcc3v3_nvme_en: vcc3v3-nvme-en {
+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+	oled {
+		oled_en: oled-en {
+			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_output_high>;
+		};
+	};
+	fan {
+		fan0_en_h: fan0-en-h {
+			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		fan1_en_h: fan1-en-h {
+			rockchip,pins = <3 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
 };
 
 &led_green {
@@ -885,8 +236,49 @@
 	};
 };
 
+// bluetooth
+&uart8 {
+	status = "okay";
+	pinctrl-0 = <&uart8m0_xfer &uart8m0_ctsn &uart8m0_rtsn>;
+	uart-has-rtscts;
+
+	bluetooth {
+		compatible = "brcm,bcm4345c5";
+		clocks = <&rk809 1>;
+		clock-names = "ext_clock";
+		host-wakeup-gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+		device-wakeup-gpios = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
+		shutdown-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+		max-speed = <1500000>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_host_wake_gpio &bt_device_wake_gpio &bt_shutdown_gpio>;
+		vbat-supply = <&vcc_3v3>;
+		vddio-supply = <&vcc_1v8>;
+	};
+};
+
+// IR receiver, but we use gpio-ir-receiver driver
 &pwm3 {
-	// IR, but use gpio
 	status = "disabled";
-	pinctrl-0 = <&pwm3_pins>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_warm: cpu_warm {
+			temperature = <68000>;
+			hysteresis = <10000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map_fan0 {
+			trip = <&cpu_warm>;
+			cooling-device = <&fan0 THERMAL_NO_LIMIT 1>;
+		};
+		map_fan1 {
+			trip = <&cpu_warm>;
+			cooling-device = <&fan1 THERMAL_NO_LIMIT 1>;
+		};
+	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3568-easepi-a2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-easepi-a2.dts
@@ -138,7 +138,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		pcie_eth0: pcie@00,0 {
+		pcie_eth0: pcie@0,0 {
 			compatible = "pci10ec,8125";
 			reg = <0x000000 0 0 0 0>;
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-easepi-r2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-easepi-r2.dts
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 
 /dts-v1/;
 
@@ -8,10 +7,15 @@
 #include <dt-bindings/soc/rockchip,vop2.h>
 #include <dt-bindings/usb/pd.h>
 #include "rk3588.dtsi"
+#include "rk3588-rk806-single.dtsi"
+#include "rk3588s-ip.dtsi"
+#include "rk3588s-ip-supply.dtsi"
+#include "rk3588-hdmirx.dtsi"
 
 / {
 	model = "EasePi R2";
 	compatible = "linkease,easepi-r2", "easepi,r2", "rockchip,rk3588";
+	eth_order =  "0004:41:00.0,0002:21:00.0,0001:11:00.0,0003:31:00.0";
 
 	aliases {
 		led-boot = &led_run;
@@ -126,7 +130,6 @@
 		pinctrl-0 = <&vdd0v95_25glan1_en>;
 		vin-supply = <&vcc_3v3_s3>;
 	};
-
 	vdd0v95_25glan2: vdd0v95-25glan2 {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd0v95_25glan2";
@@ -140,7 +143,6 @@
 		pinctrl-0 = <&vdd0v95_25glan2_en>;
 		vin-supply = <&vcc_3v3_s3>;
 	};
-
 	vdd0v95_25glan3: vdd0v95-25glan3 {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd0v95_25glan3";
@@ -154,7 +156,6 @@
 		pinctrl-0 = <&vdd0v95_25glan3_en>;
 		vin-supply = <&vcc_3v3_s3>;
 	};
-
 	vdd0v95_25glan4: vdd0v95-25glan4 {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd0v95_25glan4";
@@ -186,7 +187,7 @@
 	vbus5v0_usb: vbus5v0-usb {
 		compatible = "regulator-fixed";
 		enable-active-high;
-		gpios = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&vbus5v0_usb_en>;
 		regulator-min-microvolt = <5000000>;
@@ -199,7 +200,7 @@
 	vbus5v0_typec: vbus5v0-typec {
 		compatible = "regulator-fixed";
 		enable-active-high;
-		gpios = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&vbus5v0_typec_en>;
 		regulator-min-microvolt = <5000000>;
@@ -209,6 +210,20 @@
 	};
 #endif
 
+/*
+	wireless_bluetooth: wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		clocks = <&hym8563>;
+		clock-names = "ext_clock";
+		uart_rts_gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_LOW>;// schematic wrongly connected to GPIO4_C3
+		pinctrl-names = "default", "rts_gpio";
+		pinctrl-0 = <&uart9m0_rtsn>, <&bt_reset_gpio>, <&bt_wake_gpio>, <&bt_irq_gpio>;
+		pinctrl-1 = <&uart9m0_gpios>;
+		BT,reset_gpio = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio = <&gpio2 RK_PB6 GPIO_ACTIVE_HIGH>;
+		BT,wake_host_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+	};
+*/
 	wireless_wlan: wireless-wlan {
 		compatible = "wlan-platdata";
 		wifi_chip_type = "ap6255";
@@ -268,7 +283,6 @@
 			linux,default-trigger = "heartbeat";
 			gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
 		};
-
 		led-1 {
 			label = "green:user";
 			gpios = <&gpio3 RK_PB6 GPIO_ACTIVE_HIGH>;
@@ -287,349 +301,17 @@
 	};
 };
 
-/* ===== PMIC (RK806) ===== */
-
-&spi2 {
-	assigned-clocks = <&cru CLK_SPI2>;
-	assigned-clock-rates = <200000000>;
-	num-cs = <1>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+&combphy0_ps {
 	status = "okay";
-
-	rk806single: pmic@0 {
-		compatible = "rockchip,rk806";
-		reg = <0x0>;
-
-		interrupt-parent = <&gpio0>;
-		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
-			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
-
-		/* 0: restart PMU;
-		 * 1: reset all the power off reset registers,
-		 *    forcing the state to switch to ACTIVE mode;
-		 * 2: Reset all the power off reset registers,
-		 *    forcing the state to switch to ACTIVE mode,
-		 *    and simultaneously pull down the RESETB PIN for 5mS before releasing
-		 */
-		// pmic-reset-func = <1>;
-		rockchip,reset-mode = <1>;
-		/*
-		 * pwrkey long press off time, unit is seconds.
-		 * available values are 6, 8, 10, and 12 seconds. default is 6 seconds.
-		 */
-		long-press-off-time-sec = <10>;
-		spi-max-frequency = <1000000>;
-		system-power-controller;
-
-		vcc1-supply = <&vcc5v0_sys>;
-		vcc2-supply = <&vcc5v0_sys>;
-		vcc3-supply = <&vcc5v0_sys>;
-		vcc4-supply = <&vcc5v0_sys>;
-		vcc5-supply = <&vcc5v0_sys>;
-		vcc6-supply = <&vcc5v0_sys>;
-		vcc7-supply = <&vcc5v0_sys>;
-		vcc8-supply = <&vcc5v0_sys>;
-		vcc9-supply = <&vcc5v0_sys>;
-		vcc10-supply = <&vcc5v0_sys>;
-		vcc11-supply = <&vcc_2v0_pldo_s3>;
-		vcc12-supply = <&vcc5v0_sys>;
-		vcc13-supply = <&vcc_1v1_nldo_s3>;
-		vcc14-supply = <&vcc_1v1_nldo_s3>;
-		vcca-supply = <&vcc5v0_sys>;
-
-		gpio-controller;
-		#gpio-cells = <2>;
-
-		rk806_dvs1_null: dvs1-null-pins {
-			pins = "gpio_pwrctrl1";
-			function = "pin_fun0";
-		};
-
-		rk806_dvs2_null: dvs2-null-pins {
-			pins = "gpio_pwrctrl2";
-			function = "pin_fun0";
-		};
-
-		rk806_dvs3_null: dvs3-null-pins {
-			pins = "gpio_pwrctrl3";
-			function = "pin_fun0";
-		};
-
-		regulators {
-			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
-				regulator-boot-on;
-				regulator-min-microvolt = <550000>;
-				regulator-max-microvolt = <950000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_gpu_s0";
-				regulator-enable-ramp-delay = <400>;
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <550000>;
-				regulator-max-microvolt = <950000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_cpu_lit_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_log_s0: dcdc-reg3 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <675000>;
-				regulator-max-microvolt = <750000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_log_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-					regulator-suspend-microvolt = <750000>;
-				};
-			};
-
-			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <550000>;
-				regulator-max-microvolt = <950000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_vdenc_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_ddr_s0: dcdc-reg5 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <675000>;
-				regulator-max-microvolt = <900000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_ddr_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-					regulator-suspend-microvolt = <850000>;
-				};
-			};
-
-			vdd2_ddr_s3: dcdc-reg6 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-name = "vdd2_ddr_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-				};
-			};
-
-			vcc_2v0_pldo_s3: dcdc-reg7 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <2000000>;
-				regulator-max-microvolt = <2000000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vdd_2v0_pldo_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <2000000>;
-				};
-			};
-
-			vcc_3v3_s3: dcdc-reg8 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <3300000>;
-				regulator-max-microvolt = <3300000>;
-				regulator-name = "vcc_3v3_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <3300000>;
-				};
-			};
-
-			vddq_ddr_s0: dcdc-reg9 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-name = "vddq_ddr_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc_1v8_s3: dcdc-reg10 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-				regulator-name = "vcc_1v8_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <1800000>;
-				};
-			};
-
-			avcc_1v8_s0: pldo-reg1 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-				regulator-name = "avcc_1v8_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-					regulator-suspend-microvolt = <1800000>;
-				};
-			};
-
-			vcc_1v8_s0: pldo-reg2 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-				regulator-name = "vcc_1v8_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-					regulator-suspend-microvolt = <1800000>;
-				};
-			};
-
-			avdd_1v2_s0: pldo-reg3 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1200000>;
-				regulator-max-microvolt = <1200000>;
-				regulator-name = "avdd_1v2_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vcc_3v3_s0: avcc_3v3_s0: pldo-reg4 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <3300000>;
-				regulator-max-microvolt = <3300000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "avcc_3v3_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vccio_sd_s0: pldo-reg5 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <3300000>;
-				regulator-ramp-delay = <12500>;
-				regulator-name = "vccio_sd_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			pldo6_s3: pldo-reg6 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <1800000>;
-				regulator-max-microvolt = <1800000>;
-				regulator-name = "pldo6_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <1800000>;
-				};
-			};
-
-			vdd_0v75_s3: nldo-reg1 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <750000>;
-				regulator-max-microvolt = <750000>;
-				regulator-name = "vdd_0v75_s3";
-
-				regulator-state-mem {
-					regulator-on-in-suspend;
-					regulator-suspend-microvolt = <750000>;
-				};
-			};
-
-			vdd_ddr_pll_s0: avdd_ddr_pll_s0: nldo-reg2 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <850000>;
-				regulator-max-microvolt = <850000>;
-				regulator-name = "avdd_ddr_pll_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-					regulator-suspend-microvolt = <850000>;
-				};
-			};
-
-			avdd_0v75_s0: nldo-reg3 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <837500>;
-				regulator-max-microvolt = <837500>;
-				regulator-name = "avdd_0v75_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_0v85_s0: avdd_0v85_s0: nldo-reg4 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <850000>;
-				regulator-max-microvolt = <850000>;
-				regulator-name = "avdd_0v85_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-
-			vdd_0v75_s0: nldo-reg5 {
-				regulator-always-on;
-				regulator-boot-on;
-				regulator-min-microvolt = <750000>;
-				regulator-max-microvolt = <750000>;
-				regulator-name = "vdd_0v75_s0";
-
-				regulator-state-mem {
-					regulator-off-in-suspend;
-				};
-			};
-		};
-	};
 };
 
-/* ===== CPU Power ===== */
+&combphy1_ps {
+	status = "okay";
+};
+
+&combphy2_psu {
+	status = "okay";
+};
 
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
@@ -703,19 +385,6 @@
 	};
 };
 
-/* ===== GPU ===== */
-
-&gpu {
-	mali-supply = <&vdd_gpu_s0>;
-	status = "okay";
-};
-
-&pd_gpu {
-	domain-supply = <&vdd_gpu_s0>;
-};
-
-/* ===== NPU ===== */
-
 &i2c1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c1m2_xfer>;
@@ -737,43 +406,8 @@
 			regulator-off-in-suspend;
 		};
 	};
-};
 
-&pd_npu {
-	domain-supply = <&vdd_npu_s0>;
 };
-
-&rknn_core_0 {
-	npu-supply = <&vdd_npu_s0>;
-	sram-supply = <&vdd_npu_s0>;
-	status = "okay";
-};
-
-&rknn_core_1 {
-	npu-supply = <&vdd_npu_s0>;
-	sram-supply = <&vdd_npu_s0>;
-	status = "okay";
-};
-
-&rknn_core_2 {
-	npu-supply = <&vdd_npu_s0>;
-	sram-supply = <&vdd_npu_s0>;
-	status = "okay";
-};
-
-&rknn_mmu_0 {
-	status = "okay";
-};
-
-&rknn_mmu_1 {
-	status = "okay";
-};
-
-&rknn_mmu_2 {
-	status = "okay";
-};
-
-/* ===== I2C / RTC ===== */
 
 &i2c2 {
 	pinctrl-names = "default";
@@ -806,25 +440,6 @@
 	status = "okay";
 };
 
-/* ===== PCIe ===== */
-
-&combphy0_ps {
-	status = "okay";
-};
-
-&combphy1_ps {
-	status = "okay";
-};
-
-&combphy2_psu {
-	status = "okay";
-};
-
-&pcie30phy {
-	data-lanes = <1 3 2 4>;
-	status = "okay";
-};
-
 &pcie2x1l0 {
 	// pcie30phy lane3, p0l1, 0002:20:00.0 => rtl8125 (lan1,eth1)
 	pinctrl-names = "default";
@@ -854,6 +469,13 @@
 	status = "okay";
 };
 
+&pcie30phy {
+	// divided into 4 lanes
+	// rockchip,pcie30-phymode = <PHY_MODE_PCIE_NABIBI>;
+	data-lanes = <1 3 2 4>;
+	status = "okay";
+};
+
 &pcie3x2 {
 	// pcie30phy lane2, p1l0, 0001:10:00.0 => rtl8125 (lan2,eth2)
 	pinctrl-names = "default";
@@ -874,14 +496,11 @@
 	status = "okay";
 };
 
-/* ===== Pin Control ===== */
-
 &pinctrl {
 	leds {
 		led_run_en: led_run_en {
 			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-
 		led_user_en: led_user_en {
 			rockchip,pins = <3 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
@@ -892,7 +511,6 @@
 			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	pcie {
 		pcie2_0_rst: pcie2-0-rst {
 			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -914,47 +532,40 @@
 			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	pcie-nics {
 		vdd0v95_25glan1_en: vdd0v95-25glan1-en {
 			rockchip,pins = <3 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-
 		vdd0v95_25glan2_en: vdd0v95-25glan2-en {
 			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-
 		vdd0v95_25glan3_en: vdd0v95-25glan3-en {
 			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-
 		vdd0v95_25glan4_en: vdd0v95-25glan4-en {
 			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	nvme {
 		nvme_power_en: nvme-power-en {
 			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	power {
 		vcc3v3_power_en: vcc3v3_power_en {
 			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	hym8563 {
 		rtc_int: rtc-int {
 			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
-
 	usb {
 		vbus5v0_usb_en: vbus5v0_usb_en {
 			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+
 	};
 
 	usb-typec {
@@ -980,35 +591,29 @@
 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
 		};
 	};
-
 	wireless-wlan {
 		wifi_host_wake_irq: wifi-host-wake-irq {
 			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_down>;
 		};
 	};
-
 	sdio-pwrseq {
 		wifi_enable_h: wifi-enable-h {
 			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	ir-receiver {
 		ir_receiver_pin: ir-receiver-pin {
 			rockchip,pins = <3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	fan {
 		fan0_en_h: fan0-en-h {
 			rockchip,pins = <3 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-
 		fan1_en_h: fan1-en-h {
 			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
 	hdmirx {
 		hdmirx_hpd: hdmirx-5v-detection {
 			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -1016,8 +621,26 @@
 	};
 };
 
-/* ===== Storage ===== */
+&pwm3 {
+	// IR, but use gpio
+	status = "disabled";
+	pinctrl-0 = <&pwm3m1_pins>;
+};
 
+&saradc {
+	vref-supply = <&avcc_1v8_s0>;
+	status = "okay";
+};
+
+&sata1 {
+	status = "okay";
+};
+
+&sata2 {
+	status = "okay";
+};
+
+// eMMC
 &sdhci {
 	bus-width = <8>;
 	no-sdio;
@@ -1029,6 +652,7 @@
 	status = "okay";
 };
 
+// TF Card slot
 &sdmmc {
 	bus-width = <4>;
 	cap-mmc-highspeed;
@@ -1043,6 +667,7 @@
 	status = "okay";
 };
 
+// WiFi SDIO
 &sdio {
 	bus-width = <4>;
 	cap-sd-highspeed;
@@ -1058,28 +683,23 @@
 	sd-uhs-sdr50;
 	sd-uhs-sdr104;
 	supports-sdio;
+	// vmmc-supply = <&vcc_1v8_s3>;
+	// vqmmc-supply = <&vcc_1v8_s0>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&sdiom0_pins>;
 	status = "okay";
 };
 
-/* ===== SATA ===== */
-
-&sata1 {
+&tsadc {
 	status = "okay";
 };
-
-&sata2 {
-	status = "okay";
-};
-
-/* ===== UART ===== */
 
 &uart0 {
 	pinctrl-0 = <&uart0m2_xfer>;
 	status = "okay";
 };
 
+// debug uart
 &uart2 {
 	pinctrl-0 = <&uart2m0_xfer>;
 	status = "okay";
@@ -1090,15 +710,20 @@
 	status = "okay";
 };
 
+// bluetooth
 &uart9 {
 	pinctrl-0 = <&uart9m0_xfer &uart9m0_ctsn &uart9m0_rtsn>;
 	status = "okay";
 	uart-has-rtscts;
-
 	bluetooth {
 		compatible = "brcm,bcm4345c5";
 		clocks = <&hym8563>;
 		clock-names = "ext_clock";
+		/*
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PA0 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-names = "host-wakeup";
+		*/
 		host-wakeup-gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
 		device-wakeup-gpios = <&gpio2 RK_PB6 GPIO_ACTIVE_HIGH>;
 		shutdown-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
@@ -1109,8 +734,6 @@
 		vddio-supply = <&vcc_1v8_s3>;
 	};
 };
-
-/* ===== USB ===== */
 
 // type-c for firmware update
 &u2phy0 {
@@ -1149,14 +772,6 @@
 	status = "okay";
 };
 
-&usb_host0_ehci {
-	status = "okay";
-};
-
-&usb_host0_ohci {
-	status = "okay";
-};
-
 // usb 3.0
 &u2phy1 {
 	status = "okay";
@@ -1177,14 +792,6 @@
 	status = "okay";
 };
 
-&usb_host1_ehci {
-	status = "okay";
-};
-
-&usb_host1_ohci {
-	status = "okay";
-};
-
 // 4G modem
 &u2phy2 {
 	status = "okay";
@@ -1192,6 +799,14 @@
 
 &u2phy2_host {
 	phy-supply = <&vcc3v8_modem>;
+	status = "okay";
+};
+
+&usb_host0_ehci {
+	status = "okay";
+};
+
+&usb_host0_ohci {
 	status = "okay";
 };
 
@@ -1205,8 +820,15 @@
 	status = "okay";
 };
 
-/* ===== HDMI / Display ===== */
+&usb_host1_ehci {
+	status = "okay";
+};
 
+&usb_host1_ohci {
+	status = "okay";
+};
+
+// display
 &hdmi0 {
 	frl-enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
@@ -1224,15 +846,15 @@
 	};
 };
 
-&hdptxphy0 {
-	status = "okay";
-};
-
 &i2s5_8ch {
 	status = "okay";
 };
 
 &hdmi0_sound {
+	status = "okay";
+};
+
+&hdptxphy0 {
 	status = "okay";
 };
 
@@ -1251,8 +873,6 @@
 	};
 };
 
-/* ===== HDMI RX ===== */
-
 &hdmi_receiver_cma {
 	status = "okay";
 };
@@ -1263,23 +883,8 @@
 
 &hdmi_receiver {
 	hpd-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
+	//hpd-is-active-low;
 	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
 	pinctrl-names = "default";
 	status = "okay";
-};
-
-/* ===== Other ===== */
-
-&saradc {
-	vref-supply = <&avcc_1v8_s0>;
-	status = "okay";
-};
-
-&tsadc {
-	status = "okay";
-};
-
-&pwm3 {
-	status = "disabled";
-	pinctrl-0 = <&pwm3m1_pins>;
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-hdmirx.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-hdmirx.dtsi
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
+ * Copyright (c) 2026 jjm2473 <jjm2473@gmail.com>
+ */
+
+&hdmi_receiver {
+	compatible = "rockchip,rk3588-hdmirx-ctrler", "rockchip,hdmirx-ctrler";
+	interrupts = <GIC_SPI 177 IRQ_TYPE_LEVEL_HIGH 0>,
+				<GIC_SPI 436 IRQ_TYPE_LEVEL_HIGH 0>,
+				<GIC_SPI 179 IRQ_TYPE_LEVEL_HIGH 0>;
+	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
## Changes

### EasePi A2 (rk3568-easepi-a2.dts)
- Refactor to template-based DTS using `rk3568-roc-k40pro.dtsi`
- Add dual gpio-fan support (fan0: GPIO4_PC2, fan1: GPIO3_PA5) with thermal cooling-map
- Add OLED enable pinctrl (GPIO3_PB0)
- Add BCM4345C5 Bluetooth support
- Fix PCIe initialization by removing PIPE_DFT clock references

### EasePi R2 (rk3588-easepi-r2.dts)
- Refactor PMIC config to use `rk3588-rk806-single.dtsi`
- Add `eth_order` property for network interface ordering
- Add HDMI RX support via `rk3588-hdmirx.dtsi`
- Fix `gpios` to `gpio` property name for vbus5v0 regulators

### New file
- `rk3588-hdmirx.dtsi`: HDMI receiver controller configuration

## Test
- Verified on EasePi A2 and R2 hardware: fan control, OLED display, Ethernet, Bluetooth, PCIe