### PR TITLE
wifi: mt7668: adapt remain_on_channel to new rx_addr parameter

### DIFF
--- a/drivers/net/wireless/mediatek/mt7668/os/linux/gl_cfg80211.c
+++ b/drivers/net/wireless/mediatek/mt7668/os/linux/gl_cfg80211.c
@@ -1675,7 +1675,8 @@ void mtk_cfg80211_mgmt_frame_register(IN struct wiphy *wiphy,
 /*----------------------------------------------------------------------------*/
 int mtk_cfg80211_remain_on_channel(struct wiphy *wiphy,
 				   struct wireless_dev *wdev,
-				   struct ieee80211_channel *chan, unsigned int duration, u64 *cookie)
+				   struct ieee80211_channel *chan, unsigned int duration, u64 *cookie,
+				   const u8 *rx_addr)
 {
 	P_GLUE_INFO_T prGlueInfo = NULL;
 	INT_32 i4Rslt = -EINVAL;

--- a/drivers/net/wireless/mediatek/mt7668/os/linux/gl_p2p_cfg80211.c
+++ b/drivers/net/wireless/mediatek/mt7668/os/linux/gl_p2p_cfg80211.c
@@ -1916,7 +1916,8 @@ int mtk_p2p_cfg80211_disassoc(struct wiphy *wiphy, struct net_device *dev, struc
 
 int mtk_p2p_cfg80211_remain_on_channel(struct wiphy *wiphy,
 				       struct wireless_dev *wdev,
-				       struct ieee80211_channel *chan, unsigned int duration, u64 *cookie)
+				       struct ieee80211_channel *chan, unsigned int duration, u64 *cookie,
+				       const u8 *rx_addr)
 {
 	INT_32 i4Rslt = -EINVAL;
 	P_GLUE_INFO_T prGlueInfo = (P_GLUE_INFO_T) NULL;

--- a/drivers/net/wireless/mediatek/mt7668/os/linux/include/gl_cfg80211.h
+++ b/drivers/net/wireless/mediatek/mt7668/os/linux/include/gl_cfg80211.h
@@ -183,7 +183,8 @@ int mtk_cfg80211_set_rekey_data(struct wiphy *wiphy, struct net_device *dev, str
 
 int mtk_cfg80211_remain_on_channel(struct wiphy *wiphy,
 				   struct wireless_dev *wdev,
-				   struct ieee80211_channel *chan, unsigned int duration, u64 *cookie);
+				   struct ieee80211_channel *chan, unsigned int duration, u64 *cookie,
+				   const u8 *rx_addr);
 
 int mtk_cfg80211_cancel_remain_on_channel(struct wiphy *wiphy, struct wireless_dev *wdev, u64 cookie);
 #if KERNEL_VERSION(3, 14, 0) <= CFG80211_VERSION_CODE

--- a/drivers/net/wireless/mediatek/mt7668/os/linux/include/gl_p2p_ioctl.h
+++ b/drivers/net/wireless/mediatek/mt7668/os/linux/include/gl_p2p_ioctl.h
@@ -407,7 +407,8 @@ int mtk_p2p_cfg80211_get_txpower(struct wiphy *wiphy, struct wireless_dev *wdev,
 
 int mtk_p2p_cfg80211_remain_on_channel(struct wiphy *wiphy,
 				       struct wireless_dev *wdev,
-				       struct ieee80211_channel *chan, unsigned int duration, u64 *cookie);
+				       struct ieee80211_channel *chan, unsigned int duration, u64 *cookie,
+				       const u8 *rx_addr);
 
 int mtk_p2p_cfg80211_cancel_remain_on_channel(struct wiphy *wiphy, struct wireless_dev *wdev, u64 cookie);
 


### PR DESCRIPTION
Upstream cfg80211 commit bd912eb38 ("wifi: cfg80211: Add MAC address filter to remain_on_channel") added an optional const u8 *rx_addr parameter to the remain_on_channel callback. Update both mtk_cfg80211_remain_on_channel and mtk_p2p_cfg80211_remain_on_channel (declarations and definitions) to the new signature. The parameter is unused by this driver. Fixes the build against current linux-6.18.y.